### PR TITLE
feat: configurable GitHub Enterprise URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This Chrome extension replaces relative time expressions on GitHub with absolute
 ## Features
 
 - Converts relative time expressions (e.g., "2 days ago") to absolute dates and times (e.g., "9/14/24, 4:25 PM")
+- Works on self-hosted GitHub Enterprise instances via configurable URLs (no need to edit the manifest)
 
 ## Installation
 
@@ -25,7 +26,18 @@ This Chrome extension replaces relative time expressions on GitHub with absolute
 
 ## Usage
 
-Once installed, the extension will automatically convert relative times to absolute dates and times on GitHub pages. 
+Once installed, the extension will automatically convert relative times to absolute dates and times on GitHub pages.
+
+### GitHub Enterprise / self-hosted instances
+
+If your organization runs GitHub on a custom domain (e.g. `https://github.mycompany.com`), you can enable the extension there without editing any files:
+
+1. Click the extension icon to open the popup.
+2. Under **GitHub Enterprise URLs**, enter your instance URL and click **Add**.
+3. Chrome will ask you to grant access to that site — approve it.
+4. Reload the tab; relative times will now be converted.
+
+To stop the extension from running on a site, remove it from the same list (this also revokes the granted permission).
 
 ## Development
 

--- a/background.js
+++ b/background.js
@@ -77,6 +77,19 @@ async function reconcileFromGrantedPermissions() {
   }
 }
 
+async function storeGrantedHost(pattern) {
+  if (!pattern || !(await chrome.permissions.contains({ origins: [pattern] }))) {
+    return false;
+  }
+
+  const { [STORAGE_KEY]: customHosts = [] } = await chrome.storage.sync.get(STORAGE_KEY);
+  if (!customHosts.includes(pattern)) {
+    await chrome.storage.sync.set({ [STORAGE_KEY]: customHosts.concat(pattern) });
+  }
+  await syncRegistrations();
+  return true;
+}
+
 chrome.runtime.onInstalled.addListener(async () => {
   await reconcileFromGrantedPermissions();
   await syncRegistrations();
@@ -126,5 +139,12 @@ chrome.runtime.onMessage.addListener((request, _sender, sendResponse) => {
       .then(() => sendResponse({ ok: true }))
       .catch((err) => sendResponse({ ok: false, error: String(err) }));
     return true; // Keep the message channel open for the async response.
+  }
+
+  if (request && request.action === 'storeGrantedHost') {
+    storeGrantedHost(request.pattern)
+      .then((stored) => sendResponse({ ok: true, stored }))
+      .catch((err) => sendResponse({ ok: false, error: String(err) }));
+    return true;
   }
 });

--- a/background.js
+++ b/background.js
@@ -90,6 +90,39 @@ async function storeGrantedHost(pattern) {
   return true;
 }
 
+async function customHostStatuses() {
+  const { [STORAGE_KEY]: customHosts = [] } = await chrome.storage.sync.get(STORAGE_KEY);
+  const statuses = [];
+  for (const pattern of customHosts) {
+    let granted = false;
+    try {
+      granted = await chrome.permissions.contains({ origins: [pattern] });
+    } catch (_) {
+      granted = false;
+    }
+    statuses.push({ pattern, granted });
+  }
+  return statuses;
+}
+
+async function removeCustomHost(pattern) {
+  const { [STORAGE_KEY]: customHosts = [] } = await chrome.storage.sync.get(STORAGE_KEY);
+  const filtered = customHosts.filter((host) => host !== pattern);
+  if (filtered.length !== customHosts.length) {
+    await chrome.storage.sync.set({ [STORAGE_KEY]: filtered });
+  }
+
+  try {
+    if (await chrome.permissions.contains({ origins: [pattern] })) {
+      await chrome.permissions.remove({ origins: [pattern] });
+    }
+  } catch (_) {
+    // Ignore invalid or already-removed permissions.
+  }
+
+  await syncRegistrations();
+}
+
 chrome.runtime.onInstalled.addListener(async () => {
   await reconcileFromGrantedPermissions();
   await syncRegistrations();
@@ -144,6 +177,20 @@ chrome.runtime.onMessage.addListener((request, _sender, sendResponse) => {
   if (request && request.action === 'storeGrantedHost') {
     storeGrantedHost(request.pattern)
       .then((stored) => sendResponse({ ok: true, stored }))
+      .catch((err) => sendResponse({ ok: false, error: String(err) }));
+    return true;
+  }
+
+  if (request && request.action === 'getCustomHostStatuses') {
+    customHostStatuses()
+      .then((hosts) => sendResponse({ ok: true, hosts }))
+      .catch((err) => sendResponse({ ok: false, error: String(err) }));
+    return true;
+  }
+
+  if (request && request.action === 'removeCustomHost') {
+    removeCustomHost(request.pattern)
+      .then(() => sendResponse({ ok: true }))
       .catch((err) => sendResponse({ ok: false, error: String(err) }));
     return true;
   }

--- a/background.js
+++ b/background.js
@@ -56,17 +56,68 @@ async function syncRegistrations() {
   }
 }
 
-chrome.runtime.onInstalled.addListener(() => {
-  syncRegistrations();
+// Recover hosts that were granted but never recorded in storage (e.g. granted
+// by an older version, or when the popup closed before its callback ran). Only
+// optional host permissions the user granted show up here; the default static
+// content-script hosts are not returned by getAll().
+async function reconcileFromGrantedPermissions() {
+  let all;
+  try {
+    all = await chrome.permissions.getAll();
+  } catch (_) {
+    return;
+  }
+  const origins = customHostOrigins(all);
+  if (origins.length === 0) return;
+
+  const { [STORAGE_KEY]: customHosts = [] } = await chrome.storage.sync.get(STORAGE_KEY);
+  const merged = Array.from(new Set(customHosts.concat(origins)));
+  if (merged.length !== customHosts.length) {
+    await chrome.storage.sync.set({ [STORAGE_KEY]: merged });
+  }
+}
+
+chrome.runtime.onInstalled.addListener(async () => {
+  await reconcileFromGrantedPermissions();
+  await syncRegistrations();
 });
 
-chrome.runtime.onStartup.addListener(() => {
-  syncRegistrations();
+chrome.runtime.onStartup.addListener(async () => {
+  await reconcileFromGrantedPermissions();
+  await syncRegistrations();
 });
 
-// Re-sync when the user revokes an optional permission from chrome://extensions.
-chrome.permissions.onRemoved.addListener(() => {
-  syncRegistrations();
+// Only track https host patterns the user grants for custom hosts. This
+// excludes non-host optional permissions and keeps the stored list clean.
+function customHostOrigins(permissions) {
+  return ((permissions && permissions.origins) || []).filter((origin) =>
+    /^https:\/\//.test(origin)
+  );
+}
+
+// Persist granted hosts here rather than in the popup. Requesting a permission
+// from the popup can close it before its callback runs (notably on macOS), so
+// the popup can't be trusted to save the host. onAdded always fires.
+chrome.permissions.onAdded.addListener(async (permissions) => {
+  const origins = customHostOrigins(permissions);
+  if (origins.length === 0) return;
+
+  const { [STORAGE_KEY]: customHosts = [] } = await chrome.storage.sync.get(STORAGE_KEY);
+  const merged = Array.from(new Set(customHosts.concat(origins)));
+  await chrome.storage.sync.set({ [STORAGE_KEY]: merged });
+  await syncRegistrations();
+});
+
+// Keep storage in sync when a permission is revoked (from the popup or from
+// chrome://extensions) and re-register accordingly.
+chrome.permissions.onRemoved.addListener(async (permissions) => {
+  const origins = customHostOrigins(permissions);
+  if (origins.length > 0) {
+    const { [STORAGE_KEY]: customHosts = [] } = await chrome.storage.sync.get(STORAGE_KEY);
+    const filtered = customHosts.filter((host) => !origins.includes(host));
+    await chrome.storage.sync.set({ [STORAGE_KEY]: filtered });
+  }
+  await syncRegistrations();
 });
 
 chrome.runtime.onMessage.addListener((request, _sender, sendResponse) => {

--- a/background.js
+++ b/background.js
@@ -1,0 +1,79 @@
+// Registers the content script on user-configured GitHub Enterprise hosts.
+//
+// The default hosts (github.com and the baked-in SAP hosts) stay in the static
+// `content_scripts` entry in the manifest, so existing users are unaffected.
+// Only custom hosts added through the popup are handled here, gated behind an
+// optional host permission the user explicitly grants.
+
+const STORAGE_KEY = 'customHosts';
+const DYNAMIC_SCRIPT_ID = 'custom-github-hosts';
+
+// Keep only hosts the user has actually granted permission for. A host can be
+// in storage but have its permission revoked from chrome://extensions.
+async function grantedHosts() {
+  const { [STORAGE_KEY]: customHosts = [] } = await chrome.storage.sync.get(STORAGE_KEY);
+  const granted = [];
+  for (const pattern of customHosts) {
+    try {
+      if (await chrome.permissions.contains({ origins: [pattern] })) {
+        granted.push(pattern);
+      }
+    } catch (_) {
+      // Ignore invalid patterns.
+    }
+  }
+  return granted;
+}
+
+async function syncRegistrations() {
+  const matches = await grantedHosts();
+
+  let existing = [];
+  try {
+    existing = await chrome.scripting.getRegisteredContentScripts({ ids: [DYNAMIC_SCRIPT_ID] });
+  } catch (_) {
+    existing = [];
+  }
+
+  if (matches.length === 0) {
+    if (existing.length > 0) {
+      await chrome.scripting.unregisterContentScripts({ ids: [DYNAMIC_SCRIPT_ID] });
+    }
+    return;
+  }
+
+  const script = {
+    id: DYNAMIC_SCRIPT_ID,
+    js: ['content.js'],
+    matches,
+    runAt: 'document_idle'
+  };
+
+  if (existing.length > 0) {
+    await chrome.scripting.updateContentScripts([script]);
+  } else {
+    await chrome.scripting.registerContentScripts([script]);
+  }
+}
+
+chrome.runtime.onInstalled.addListener(() => {
+  syncRegistrations();
+});
+
+chrome.runtime.onStartup.addListener(() => {
+  syncRegistrations();
+});
+
+// Re-sync when the user revokes an optional permission from chrome://extensions.
+chrome.permissions.onRemoved.addListener(() => {
+  syncRegistrations();
+});
+
+chrome.runtime.onMessage.addListener((request, _sender, sendResponse) => {
+  if (request && request.action === 'syncCustomHosts') {
+    syncRegistrations()
+      .then(() => sendResponse({ ok: true }))
+      .catch((err) => sendResponse({ ok: false, error: String(err) }));
+    return true; // Keep the message channel open for the async response.
+  }
+});

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "GitHub Absolute Dates Plugin",
-    "version": "0.0.17",
+    "version": "0.0.18",
     "description": "Display absolute dates on GitHub pages instead of relative time",
     "icons": {
         "16": "icons/icon16.png",
@@ -9,8 +9,15 @@
         "128": "icons/icon128.png"
     },
     "permissions": [
-        "storage"
+        "storage",
+        "scripting"
     ],
+    "optional_host_permissions": [
+        "https://*/*"
+    ],
+    "background": {
+        "service_worker": "background.js"
+    },
     "action": {
         "default_popup": "popup.html",
         "default_title": "GitHub Absolute Time Settings"

--- a/popup.html
+++ b/popup.html
@@ -162,6 +162,32 @@
             white-space: nowrap;
         }
 
+        .host-label {
+            min-width: 0;
+        }
+
+        .host-actions {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            flex-shrink: 0;
+        }
+
+        .grant-host-button {
+            border: 1px solid #0969da;
+            background: #ffffff;
+            color: #0969da;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 10px;
+            padding: 2px 6px;
+            white-space: nowrap;
+        }
+
+        .grant-host-button:hover {
+            background: #ddf4ff;
+        }
+
         .remove-host-button {
             border: none;
             background: transparent;

--- a/popup.html
+++ b/popup.html
@@ -108,6 +108,75 @@
             line-height: 1.4;
         }
 
+        .host-input-row {
+            display: flex;
+            gap: 6px;
+        }
+
+        .host-input-row .format-input {
+            flex: 1;
+        }
+
+        .add-host-button {
+            padding: 6px 12px;
+            background-color: #0969da;
+            color: white;
+            border: none;
+            border-radius: 4px;
+            font-size: 12px;
+            font-weight: 500;
+            cursor: pointer;
+            white-space: nowrap;
+            transition: background-color 0.2s;
+        }
+
+        .add-host-button:hover {
+            background-color: #0a5cc7;
+        }
+
+        .host-list {
+            list-style: none;
+            margin: 8px 0 0 0;
+            padding: 0;
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+        }
+
+        .host-list li {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 6px;
+            padding: 5px 8px;
+            background-color: #f6f8fa;
+            border: 1px solid #d0d7de;
+            border-radius: 4px;
+            font-size: 11px;
+            color: #24292f;
+        }
+
+        .host-list li span {
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+
+        .remove-host-button {
+            border: none;
+            background: transparent;
+            color: #cf222e;
+            cursor: pointer;
+            font-size: 14px;
+            line-height: 1;
+            padding: 0 2px;
+            flex-shrink: 0;
+        }
+
+        .remove-host-button:hover {
+            color: #a40e26;
+        }
+
         .save-button {
             width: 100%;
             padding: 8px;
@@ -194,6 +263,18 @@
                 <div class="example">Same day shares same color</div>
             </label>
         </div>
+    </div>
+
+    <div class="setting-group">
+        <label class="setting-label">GitHub Enterprise URLs</label>
+        <div class="host-input-row">
+            <input type="text" id="hostInput" class="format-input" placeholder="https://github.mycompany.com">
+            <button class="add-host-button" id="addHostButton" type="button">Add</button>
+        </div>
+        <div class="format-help">
+            Add self-hosted GitHub URLs. You'll be asked to grant access to each site.
+        </div>
+        <ul class="host-list" id="hostList"></ul>
     </div>
 
     <button class="save-button" id="saveButton">Save Settings</button>

--- a/popup.js
+++ b/popup.js
@@ -79,43 +79,33 @@ document.addEventListener('DOMContentLoaded', function () {
                 return;
             }
 
-            // Requesting a permission requires a user gesture (this click).
+            // Persisting the host is handled by the background service worker's
+            // permissions.onAdded listener: requesting a permission can close
+            // this popup before the callback runs, so we can't rely on it here.
+            hostInput.value = '';
             chrome.permissions.request({ origins: [pattern] }, function (granted) {
                 if (chrome.runtime.lastError || !granted) {
                     showStatus('Permission not granted', 'error');
-                    return;
                 }
-
-                const updated = hosts.concat(pattern);
-                chrome.storage.sync.set({ customHosts: updated }, function () {
-                    chrome.runtime.sendMessage({ action: 'syncCustomHosts' }, function () {
-                        void chrome.runtime.lastError;
-                        hostInput.value = '';
-                        renderHosts(updated);
-                        showStatus('Site added. Reload it to see changes.', 'success');
-                    });
-                });
             });
         });
     }
 
     function removeHost(pattern) {
-        chrome.storage.sync.get(['customHosts'], function (result) {
-            const updated = (result.customHosts || []).filter(function (h) {
-                return h !== pattern;
-            });
-            chrome.storage.sync.set({ customHosts: updated }, function () {
-                chrome.permissions.remove({ origins: [pattern] }, function () {
-                    void chrome.runtime.lastError;
-                    chrome.runtime.sendMessage({ action: 'syncCustomHosts' }, function () {
-                        void chrome.runtime.lastError;
-                        renderHosts(updated);
-                        showStatus('Site removed', 'success');
-                    });
-                });
-            });
+        // Removing the permission triggers the background permissions.onRemoved
+        // listener, which updates storage and re-registers. The storage change
+        // listener below refreshes this list.
+        chrome.permissions.remove({ origins: [pattern] }, function () {
+            void chrome.runtime.lastError;
         });
     }
+
+    // Keep the list in sync when the background worker updates stored hosts.
+    chrome.storage.onChanged.addListener(function (changes, area) {
+        if (area === 'sync' && changes.customHosts) {
+            renderHosts(changes.customHosts.newValue || []);
+        }
+    });
 
     addHostButton.addEventListener('click', addHost);
     hostInput.addEventListener('keydown', function (event) {

--- a/popup.js
+++ b/popup.js
@@ -4,6 +4,9 @@ document.addEventListener('DOMContentLoaded', function () {
     const timeFormatRadios = document.querySelectorAll('input[name="timeFormat"]');
     const colorByDayCheckbox = document.getElementById('colorByDay');
     const dateFormatInput = document.getElementById('dateFormat');
+    const hostInput = document.getElementById('hostInput');
+    const addHostButton = document.getElementById('addHostButton');
+    const hostList = document.getElementById('hostList');
 
     // Load saved settings
     chrome.storage.sync.get(['timeFormat', 'colorByDay', 'dateFormat'], function (result) {
@@ -12,6 +15,117 @@ document.addEventListener('DOMContentLoaded', function () {
         colorByDayCheckbox.checked = Boolean(result.colorByDay);
         dateFormatInput.value = result.dateFormat || '';
     });
+
+    // --- Custom GitHub Enterprise host management ---
+
+    // Convert user input into a valid https match pattern (e.g. https://host/*).
+    function toMatchPattern(input) {
+        const trimmed = (input || '').trim();
+        if (!trimmed) return null;
+        let url;
+        try {
+            url = new URL(trimmed.includes('://') ? trimmed : `https://${trimmed}`);
+        } catch (_) {
+            return null;
+        }
+        if (url.protocol !== 'https:' || !url.hostname) return null;
+        return `https://${url.hostname}/*`;
+    }
+
+    function displayHost(pattern) {
+        return pattern.replace(/^https:\/\//, '').replace(/\/\*$/, '');
+    }
+
+    function renderHosts(hosts) {
+        hostList.innerHTML = '';
+        hosts.forEach(function (pattern) {
+            const li = document.createElement('li');
+            const label = document.createElement('span');
+            label.textContent = displayHost(pattern);
+            label.title = pattern;
+
+            const removeBtn = document.createElement('button');
+            removeBtn.className = 'remove-host-button';
+            removeBtn.type = 'button';
+            removeBtn.textContent = '\u00d7';
+            removeBtn.title = 'Remove';
+            removeBtn.addEventListener('click', function () {
+                removeHost(pattern);
+            });
+
+            li.appendChild(label);
+            li.appendChild(removeBtn);
+            hostList.appendChild(li);
+        });
+    }
+
+    function loadHosts() {
+        chrome.storage.sync.get(['customHosts'], function (result) {
+            renderHosts(result.customHosts || []);
+        });
+    }
+
+    function addHost() {
+        const pattern = toMatchPattern(hostInput.value);
+        if (!pattern) {
+            showStatus('Enter a valid https:// URL', 'error');
+            return;
+        }
+
+        chrome.storage.sync.get(['customHosts'], function (result) {
+            const hosts = result.customHosts || [];
+            if (hosts.includes(pattern)) {
+                showStatus('That URL is already added', 'error');
+                return;
+            }
+
+            // Requesting a permission requires a user gesture (this click).
+            chrome.permissions.request({ origins: [pattern] }, function (granted) {
+                if (chrome.runtime.lastError || !granted) {
+                    showStatus('Permission not granted', 'error');
+                    return;
+                }
+
+                const updated = hosts.concat(pattern);
+                chrome.storage.sync.set({ customHosts: updated }, function () {
+                    chrome.runtime.sendMessage({ action: 'syncCustomHosts' }, function () {
+                        void chrome.runtime.lastError;
+                        hostInput.value = '';
+                        renderHosts(updated);
+                        showStatus('Site added. Reload it to see changes.', 'success');
+                    });
+                });
+            });
+        });
+    }
+
+    function removeHost(pattern) {
+        chrome.storage.sync.get(['customHosts'], function (result) {
+            const updated = (result.customHosts || []).filter(function (h) {
+                return h !== pattern;
+            });
+            chrome.storage.sync.set({ customHosts: updated }, function () {
+                chrome.permissions.remove({ origins: [pattern] }, function () {
+                    void chrome.runtime.lastError;
+                    chrome.runtime.sendMessage({ action: 'syncCustomHosts' }, function () {
+                        void chrome.runtime.lastError;
+                        renderHosts(updated);
+                        showStatus('Site removed', 'success');
+                    });
+                });
+            });
+        });
+    }
+
+    addHostButton.addEventListener('click', addHost);
+    hostInput.addEventListener('keydown', function (event) {
+        if (event.key === 'Enter') {
+            event.preventDefault();
+            addHost();
+        }
+    });
+
+    loadHosts();
 
     // Handle save button click
     saveButton.addEventListener('click', function () {
@@ -30,14 +144,19 @@ document.addEventListener('DOMContentLoaded', function () {
             } else {
                 showStatus('Settings saved successfully!', 'success');
 
-                // Notify ALL GitHub tabs to update (not just active, since popup is open)
-                chrome.tabs.query({ url: '*://github.com/*' }, function (tabs) {
-                    tabs.forEach(function (tab) {
-                        chrome.tabs.sendMessage(tab.id, {
-                            action: 'updateSettings',
-                            timeFormat: selectedFormat,
-                            colorByDay: colorByDay,
-                            dateFormat: dateFormat
+                // Notify all GitHub tabs (default + custom hosts) to update live.
+                chrome.storage.sync.get(['customHosts'], function (result) {
+                    const urlPatterns = ['*://github.com/*'].concat(result.customHosts || []);
+                    chrome.tabs.query({ url: urlPatterns }, function (tabs) {
+                        tabs.forEach(function (tab) {
+                            chrome.tabs.sendMessage(tab.id, {
+                                action: 'updateSettings',
+                                timeFormat: selectedFormat,
+                                colorByDay: colorByDay,
+                                dateFormat: dateFormat
+                            }, function () {
+                                void chrome.runtime.lastError;
+                            });
                         });
                     });
                 });

--- a/popup.js
+++ b/popup.js
@@ -86,7 +86,21 @@ document.addEventListener('DOMContentLoaded', function () {
             chrome.permissions.request({ origins: [pattern] }, function (granted) {
                 if (chrome.runtime.lastError || !granted) {
                     showStatus('Permission not granted', 'error');
+                    return;
                 }
+
+                // If the permission was already granted, permissions.onAdded
+                // will not fire. Ask the background worker to reconcile/save it.
+                chrome.runtime.sendMessage({
+                    action: 'storeGrantedHost',
+                    pattern: pattern
+                }, function (response) {
+                    if (chrome.runtime.lastError || !response || !response.ok) {
+                        showStatus('Site permission granted, but saving failed', 'error');
+                        return;
+                    }
+                    showStatus('Site added. Reload it to see changes.', 'success');
+                });
             });
         });
     }

--- a/popup.js
+++ b/popup.js
@@ -121,22 +121,9 @@ document.addEventListener('DOMContentLoaded', function () {
             return;
         }
 
-        chrome.runtime.sendMessage({ action: 'getCustomHostStatuses' }, function (response) {
-            if (chrome.runtime.lastError || !response || !response.ok) {
-                showStatus('Could not check saved sites', 'error');
-                return;
-            }
-
-            const existing = (response.hosts || []).find(function (host) {
-                return host.pattern === pattern;
-            });
-            if (existing && existing.granted) {
-                showStatus('That URL is already added', 'error');
-                return;
-            }
-
-            requestHostPermission(pattern);
-        });
+        // Keep this request directly in the click handler path; Chrome requires
+        // optional permission prompts to be triggered by a user gesture.
+        requestHostPermission(pattern);
     }
 
     function removeHost(pattern) {

--- a/popup.js
+++ b/popup.js
@@ -36,13 +36,52 @@ document.addEventListener('DOMContentLoaded', function () {
         return pattern.replace(/^https:\/\//, '').replace(/\/\*$/, '');
     }
 
+    function requestHostPermission(pattern) {
+        hostInput.value = '';
+        chrome.permissions.request({ origins: [pattern] }, function (granted) {
+            if (chrome.runtime.lastError || !granted) {
+                showStatus('Permission not granted', 'error');
+                return;
+            }
+
+            chrome.runtime.sendMessage({
+                action: 'storeGrantedHost',
+                pattern: pattern
+            }, function (response) {
+                if (chrome.runtime.lastError || !response || !response.ok) {
+                    showStatus('Site permission granted, but saving failed', 'error');
+                    return;
+                }
+                showStatus('Site added. Reload it to see changes.', 'success');
+                loadHosts();
+            });
+        });
+    }
+
     function renderHosts(hosts) {
         hostList.innerHTML = '';
-        hosts.forEach(function (pattern) {
+        hosts.forEach(function (host) {
+            const pattern = host.pattern;
             const li = document.createElement('li');
             const label = document.createElement('span');
+            label.className = 'host-label';
             label.textContent = displayHost(pattern);
             label.title = pattern;
+
+            const actions = document.createElement('div');
+            actions.className = 'host-actions';
+
+            if (!host.granted) {
+                const grantBtn = document.createElement('button');
+                grantBtn.className = 'grant-host-button';
+                grantBtn.type = 'button';
+                grantBtn.textContent = 'Grant access';
+                grantBtn.title = 'Grant access on this device';
+                grantBtn.addEventListener('click', function () {
+                    requestHostPermission(pattern);
+                });
+                actions.appendChild(grantBtn);
+            }
 
             const removeBtn = document.createElement('button');
             removeBtn.className = 'remove-host-button';
@@ -52,16 +91,26 @@ document.addEventListener('DOMContentLoaded', function () {
             removeBtn.addEventListener('click', function () {
                 removeHost(pattern);
             });
+            actions.appendChild(removeBtn);
 
             li.appendChild(label);
-            li.appendChild(removeBtn);
+            li.appendChild(actions);
             hostList.appendChild(li);
         });
     }
 
     function loadHosts() {
-        chrome.storage.sync.get(['customHosts'], function (result) {
-            renderHosts(result.customHosts || []);
+        chrome.runtime.sendMessage({ action: 'getCustomHostStatuses' }, function (response) {
+            if (chrome.runtime.lastError || !response || !response.ok) {
+                chrome.storage.sync.get(['customHosts'], function (result) {
+                    const hosts = (result.customHosts || []).map(function (pattern) {
+                        return { pattern: pattern, granted: false };
+                    });
+                    renderHosts(hosts);
+                });
+                return;
+            }
+            renderHosts(response.hosts || []);
         });
     }
 
@@ -72,52 +121,42 @@ document.addEventListener('DOMContentLoaded', function () {
             return;
         }
 
-        chrome.storage.sync.get(['customHosts'], function (result) {
-            const hosts = result.customHosts || [];
-            if (hosts.includes(pattern)) {
+        chrome.runtime.sendMessage({ action: 'getCustomHostStatuses' }, function (response) {
+            if (chrome.runtime.lastError || !response || !response.ok) {
+                showStatus('Could not check saved sites', 'error');
+                return;
+            }
+
+            const existing = (response.hosts || []).find(function (host) {
+                return host.pattern === pattern;
+            });
+            if (existing && existing.granted) {
                 showStatus('That URL is already added', 'error');
                 return;
             }
 
-            // Persisting the host is handled by the background service worker's
-            // permissions.onAdded listener: requesting a permission can close
-            // this popup before the callback runs, so we can't rely on it here.
-            hostInput.value = '';
-            chrome.permissions.request({ origins: [pattern] }, function (granted) {
-                if (chrome.runtime.lastError || !granted) {
-                    showStatus('Permission not granted', 'error');
-                    return;
-                }
-
-                // If the permission was already granted, permissions.onAdded
-                // will not fire. Ask the background worker to reconcile/save it.
-                chrome.runtime.sendMessage({
-                    action: 'storeGrantedHost',
-                    pattern: pattern
-                }, function (response) {
-                    if (chrome.runtime.lastError || !response || !response.ok) {
-                        showStatus('Site permission granted, but saving failed', 'error');
-                        return;
-                    }
-                    showStatus('Site added. Reload it to see changes.', 'success');
-                });
-            });
+            requestHostPermission(pattern);
         });
     }
 
     function removeHost(pattern) {
-        // Removing the permission triggers the background permissions.onRemoved
-        // listener, which updates storage and re-registers. The storage change
-        // listener below refreshes this list.
-        chrome.permissions.remove({ origins: [pattern] }, function () {
-            void chrome.runtime.lastError;
+        chrome.runtime.sendMessage({
+            action: 'removeCustomHost',
+            pattern: pattern
+        }, function (response) {
+            if (chrome.runtime.lastError || !response || !response.ok) {
+                showStatus('Could not remove site', 'error');
+                return;
+            }
+            showStatus('Site removed', 'success');
+            loadHosts();
         });
     }
 
     // Keep the list in sync when the background worker updates stored hosts.
     chrome.storage.onChanged.addListener(function (changes, area) {
         if (area === 'sync' && changes.customHosts) {
-            renderHosts(changes.customHosts.newValue || []);
+            loadHosts();
         }
     });
 


### PR DESCRIPTION
Add a popup section to register the extension on self-hosted GitHub instances without editing the manifest (issue #13). Custom hosts are gated behind an optional host permission the user grants per-site, and a background service worker dynamically registers the content script for granted origins.

Existing hosts (github.com and baked-in SAP hosts) remain static content scripts, so current users are unaffected.

Includes-AI-Code: true